### PR TITLE
Configuracion de las herramientas.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,15 @@ Hackatón para trabajar en la asignatura IV, el 18 de noviembre de 2021
 ## Comprobar Sintaxis
 Para comprobar la sintaxis se hace uso de la orden:
   - deno compile src/*.ts
+
+## Elección de las herramientas
+A la hora de la elección de las herramientas se van a tener en cuenta una serie de criterios:
+  - Instalar el menor número de herramientas posibles.
+  - Elegir herramientas actualizadas para no generar deuda técnica.
+
+Teniendo esto en cuenta tenemos 3 runtimes como posibles opciones:
+  - Node: Trae instalado npm por defecto, por lo que podríamos usarlo como gestor de tareas y gestor de dependencias. Debido al bajo rendimiento de npm, se puede usar pnpm sin generar deuda técnica. Por contraparte, sería necesario elegir un test runner y una biblioteca de aserciones. Para instalar el menor número de herramientas posibles, podemos hacer uso de Jasmine o de Jest como test runner, ya que incluyen sus propias bibliotecas de aserciones.
+  - Deno: Deno instala dependencias mediante una URL or lo que no será necesario instalar un gestor de dependencias y puede actuar como gestor de tareas con la orden **deno task**. A la hora de los test, Deno incluye su propio test runner y si hacemos uso de la biblioteca de aserciones estándar no será necesario instalar nada.
+  - Bun: Es un runtime "todo en uno" por lo que no será necesario instalar ni gestor de tareas ni gestor de dependencias. Cuenta con su propio test runner llamado wiptest que incluye una biblioteca de aserciones, aunque en estos momentos se encuentra en fase beta por lo que podría producirnos herrores, por lo que habría que elegir un test runner y una biblioteca de aserciones al igual que en Node.
+
+Habiendo descrito todas las opciones posibles, vamos a usar Deno como runtime de la aplicación para tenerlo todo listo instalando únicamente Deno.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Hack-a-hair
 
 Hackatón para trabajar en la asignatura IV, el 18 de noviembre de 2021
+
+## Comprobar Sintaxis
+Para comprobar la sintaxis se hace uso de la orden:
+  - deno compile src/*.ts

--- a/deno.json
+++ b/deno.json
@@ -1,29 +1,13 @@
 {
   "compilerOptions": {
-    "allowJs": true,
-    "lib": ["deno.window"],
-    "strict": true
+    "AllowJs": false
   },
   "lint": {
     "files": {
-      "include": ["src/"],
-      "exclude": ["src/tests/"]
+      "include": ["src/"]
     },
     "rules": {
-      "tags": ["recommended"],
-      "include": ["ban-untagged-todo"],
-      "exclude": ["no-unused-vars"]
-    }
-  },
-  "fmt": {
-    "files": {
-      "include": ["src/"],
-      "exclude": ["src/tests/"]
-    },
-    "options": {
-      "useTabs": true,
-      "indentWidth": 2,
-      "singleQuote": true
+
     }
   },
   "tasks":{

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "AllowJs": false
+    "allowJs": false
   },
   "lint": {
     "files": {

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "lib": ["deno.window"],
+    "strict": true
+  },
+  "lint": {
+    "files": {
+      "include": ["src/"],
+      "exclude": ["src/tests/"]
+    },
+    "rules": {
+      "tags": ["recommended"],
+      "include": ["ban-untagged-todo"],
+      "exclude": ["no-unused-vars"]
+    }
+  },
+  "fmt": {
+    "files": {
+      "include": ["src/"],
+      "exclude": ["src/tests/"]
+    },
+    "options": {
+      "useTabs": true,
+      "indentWidth": 2,
+      "singleQuote": true
+    }
+  },
+  "tasks":{
+    
+  }
+}


### PR DESCRIPTION
En el fichero de configuración deno.js aparece al final una sección task, en esta sección se añaden las tareas que puede realizar el task runner. Hay que tener cuidado cuando incluimos una tarea, ya que se usa un subset de sh/bash para ejecutar las tareas.
Este subset en estos momentos no soporta los glob, aunque nos indican que lo incorporarán en el futuro.
En el fichero de configuración de Deno, se ha puesto la opción allowJs a false, por lo que los ficheros con extensión javascript no están permitidos. Las demás opciones se han dejado por defecto.

* Closes #16 porque incluye un gestor de tareas.