### PR TITLE
Eliminar atributo nombre TiempoServicio 

### DIFF
--- a/src/tiempo-servicio.ts
+++ b/src/tiempo-servicio.ts
@@ -4,17 +4,13 @@ import Duration from "https://deno.land/x/durationjs@v4.1.0/mod.ts";
 export class TiempoServicio{
 
     // Duración medio total que se tarda en realizar servicio
-    nombre: string;
-
-    // Duración medio total que se tarda en realizar servicio
     tiempoTotal: Duration;
 
     // Tiempo que se trabaja directamente sobre el cliente
     tiempoUtil: Duration;
 
     // Los tiempos han de estar en el siguiente formato: 1h1m2s
-    constructor(nombre:string, tiempoTotal:string, tiempoUtil: string){
-        this.nombre = nombre;
+    constructor(tiempoTotal:string, tiempoUtil: string){
         this.tiempoTotal = Duration.fromString(tiempoTotal);
         this.tiempoUtil = Duration.fromString(tiempoUtil);
     }


### PR DESCRIPTION
# PR en el proyecto grupal `pelooxtreem`

## Lista de comprobación:
* [x] El PR está asociado al issue #55
* [x] Se han mirado los demás issues antes de hacer el PR.
* [x] He mirado [CONTRIBUTING.md](https://github.com/JJ/pelooxtreem/blob/main/CONTRIBUTING.md) que se sigan los principios mencionados.
* [x] Me he esperado a que pasen los tests una vez hecho el PR.

## Comentarios adicionales

Fix #55

Se ha eliminado el atributo nombre de la clase tiempo-servicio.ts ya que está presente en la clase servicio.ts